### PR TITLE
Add Windows setup and bootstrap scripts

### DIFF
--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -1,0 +1,12 @@
+@echo off
+setlocal
+
+set REPO_URL=https://github.com/anfalovK/ai_kb
+set TARGET_DIR=ai_kb
+
+git clone %REPO_URL% %TARGET_DIR%
+if %errorlevel% neq 0 exit /b %errorlevel%
+cd %TARGET_DIR%
+
+call scripts\setup.bat
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+
+rem Run the Linux setup script using bash
+set SCRIPT_DIR=%~dp0
+cd /d "%SCRIPT_DIR%.."
+
+bash scripts/setup.sh
+if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
## Summary
- add `setup.bat` to run the existing Linux setup on Windows
- add `bootstrap.bat` to clone the repo and invoke the Windows setup script

## Testing
- `./scripts/setup.sh` *(fails: docker: command not found)*
- `./scripts/healthcheck.sh` *(fails: waiting for postgres...)*
- `./scripts/status.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a21f01b388832e9475a1c6644ffb18